### PR TITLE
Add --start-from-header option to aws logs get-log-events execution.

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -209,7 +209,8 @@ module Fluent::Plugin
                 log_stream_name: stream,
                 next_token: stream_token,
                 limit: @limit_events,
-                start_time: @event_start_time
+                start_time: @event_start_time,
+                start_from_head: true
               )
 
               response.events.each do |e|


### PR DESCRIPTION
Without start_from_header parameter, head of logs could be lost.
It is necessary when you want to dump out entire cloudwatch logs.