### PR TITLE
Some major fixes...

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -8,7 +8,7 @@ require 'psych'
 
 module Fluent::Plugin
   class CloudwatchIngestInput < Fluent::Plugin::Input
-    Fluent::Plugin.register_input('cloudwatch_ingest_chaeyk', self)
+    Fluent::Plugin.register_input('cloudwatch_ingest', self)
     helpers :compat_parameters, :parser
 
     desc 'The region of the source cloudwatch logs'
@@ -40,7 +40,7 @@ module Fluent::Plugin
     desc 'Fetch the oldest logs first'
     config_param :oldest_logs_first, :bool, default: false
     config_section :parse do
-      config_set_default :@type, 'cloudwatch_ingest_chaeyk'
+      config_set_default :@type, 'cloudwatch_ingest'
       desc 'Regular expression with which to parse the event message'
       config_param :expression, :string, default: '^(?<message>.+)$'
       desc 'Take the timestamp from the event rather than the expression'

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -237,8 +237,12 @@ module Fluent::Plugin
 
               # Once all events for this stream have been processed,
               # in this iteration, store the forward token
-              state.store[group][stream]['token'] = response.next_forward_token
-              state.store[group][stream]['timestamp'] = response.events.last ? response.events.last.timestamp : stream_timestamp
+              if stream_token or response.events.count > 0
+                state.store[group][stream]['token'] = response.next_forward_token
+                state.store[group][stream]['timestamp'] = response.events.last ? response.events.last.timestamp : stream_timestamp
+              else
+                state.store[group].delete(stream)
+              end
             rescue Aws::CloudWatchLogs::Errors::InvalidParameterException => boom
               log.error("cloudwatch token is expired or broken. trying with timestamp.");
 


### PR DESCRIPTION
1. print boom.insect instead of boom

2. use next_token and timestamp
   next_token is valid for 12 hours. if fluentd is down for more that 12 hours,
   api returns error, and this plugin repeats loop infinitly.
   so, we should save next_token and timestamp to statefile, and when token is invalid
   we should query with timestamp.
   And, because statefile's structure is changed, I added statefile's migration funtionality.

3. statefile should be truncated before saving.

4. changing interval policy
   I think there is 3 situation to use interval

   a. api error
   b. api success, and no data
   c. api success, and some data ingested

   When massive log aggregation is in progress, case c's interval should be small or zero.
   In case a and b, we can use large interval. So, I changed interval value to api_interval in case b.
   This breaks compatibility with version 4.0 and lower.

I'm sorry that my code is not beautiful.
It's because I don't know about ruby.