### PR TITLE
Refuse to emit blank or newline only event message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,8 @@ Both of these changes are designed to make debugging ingestion problems from hig
 ## 1.3.0
 
 * Add `log_group_exclude_regexp` to allow optional exclusion of log groups by regexp
+
+## 1.4.0
+
+* Refuse to emit records with a blank (or newline only) message
+* Emit metric `events.emitted.blocked` to expose these alongside logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@ Both of these changes are designed to make debugging ingestion problems from hig
 
 * Refuse to emit records with a blank (or newline only) message
 * Emit metric `events.emitted.blocked` to expose these alongside logging
+* Add plugin skew time to telemetry optionally emitted from the parser

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ parser.record.success
 parser.json.success     # if json parsing is enabled
 parser.json.failed      # if json parsing is enabled
 parser.ingestion_skew   # the difference between `timestamp` and `ingestion_time` as returned by the Cloudwatch API
+parser.plugin_skew      # the difference between "now" and `timestamp`
 ```
 
 ### Sub-second timestamps

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Or install it yourself as:
   limit_events 10000        # Number of events to fetch in any given iteration
   event_start_time 0        # Do not fetch events before this time (UNIX epoch, miliseconds)
   oldest_logs_first false   # When true fetch the oldest logs first
+  drop_blank_events true    # Fluentd may throw an exception if a blank event is emitted
   telemetry false           # Produce statsd telemetry
   statsd_endpoint localhost # Endpoint to which telemetry should be sent
   <parse>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ api.calls.getlogevents.attempted
 api.calls.getlogevents.failed
 api.calls.getlogevents.invalid_token
 events.emitted.success
+events.emitted.blocked
 ```
 
 Likewise when telemetry is enabled for the parser, the emitted metrics are:

--- a/lib/fluent/plugin/cloudwatch/ingest/version.rb
+++ b/lib/fluent/plugin/cloudwatch/ingest/version.rb
@@ -2,7 +2,7 @@ module Fluent
   module Plugin
     module Cloudwatch
       module Ingest
-        VERSION = '1.3.0'.freeze
+        VERSION = '1.4.0'.freeze
       end
     end
   end

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -43,6 +43,8 @@ module Fluent::Plugin
     config_param :event_start_time, :integer, default: 0
     desc 'Fetch the oldest logs first'
     config_param :oldest_logs_first, :bool, default: false
+    desc 'Refuse to emit events with a blank "message" field'
+    config_param :drop_blank_events, :bool, default: true
     desc 'Turn on telemetry'
     config_param :telemetry, :bool, default: false
     desc 'Statsd endpoint to which telemetry should be written'
@@ -136,7 +138,7 @@ module Fluent::Plugin
 
     def emit(event, log_group_name, log_stream_name)
       @parser.parse(event, log_group_name, log_stream_name) do |time, record|
-        if record.message.chomp.empty?
+        if record['message'].chomp.empty? && @drop_blank_events
           log.warn("Event is blank or contains only a newline, refusing to emit. group: #{log_group_name}, stream: #{log_stream_name}, event: #{event}") # rubocop:disable LineLength
           metric(:increment, 'events.emitted.blocked')
           next

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -136,6 +136,11 @@ module Fluent::Plugin
 
     def emit(event, log_group_name, log_stream_name)
       @parser.parse(event, log_group_name, log_stream_name) do |time, record|
+        if record.chomp.empty?
+          log.warn("Event is blank or contains only a newline, refusing to emit. group: #{log_group_name}, stream: #{log_stream_name}, event: #{event}") # rubocop:disable LineLength
+          metric(:increment, 'events.emitted.blocked')
+          next
+        end
         router.emit(@tag, time, record)
         metric(:increment, 'events.emitted.success')
       end

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -136,7 +136,7 @@ module Fluent::Plugin
 
     def emit(event, log_group_name, log_stream_name)
       @parser.parse(event, log_group_name, log_stream_name) do |time, record|
-        if record.chomp.empty?
+        if record.message.chomp.empty?
           log.warn("Event is blank or contains only a newline, refusing to emit. group: #{log_group_name}, stream: #{log_stream_name}, event: #{event}") # rubocop:disable LineLength
           metric(:increment, 'events.emitted.blocked')
           next

--- a/lib/fluent/plugin/parser_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/parser_cloudwatch_ingest.rb
@@ -94,6 +94,15 @@ module Fluent
           )
         end
 
+        # Optionally emit @timestamp and plugin ingestion time skew
+        if @telemetry
+          metric(
+            :gauge,
+            'parser.plugin_skew',
+            now - event.timestamp
+          )
+        end
+
         # We do String processing on the event time here to
         # avoid rounding errors introduced by floating point
         # arithmetic.

--- a/lib/fluent/plugin/parser_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/parser_cloudwatch_ingest.rb
@@ -99,7 +99,7 @@ module Fluent
           metric(
             :gauge,
             'parser.plugin_skew',
-            now - event.timestamp
+            now.strftime('%Q').to_i - event.timestamp
           )
         end
 


### PR DESCRIPTION
The fluentd event router does not gracefully handle events that are
blank or consist only of a newline character. Refuse to emit records
like this, and produce telemetry and logging to indicate so.