### PR TITLE
Always store next token to break the loop after the last batch

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -230,9 +230,7 @@ module Fluent::Plugin
                    end
 
         response.log_streams.each { |s| log_streams << s.log_stream_name }
-        if log_streams.size == @max_log_streams_per_group
-          @log_streams_next_token = response.next_token
-        end
+        @log_streams_next_token = response.next_token
       rescue StandardError => boom
         prefix_message = if log_stream_name_prefix.empty?
                            ''


### PR DESCRIPTION
This fixes the endless loop if a LogGroup has more than 50 LogStreams.