### PR TITLE
Ingest does not stop if streams > max_log_streams_per_group

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -230,9 +230,8 @@ module Fluent::Plugin
                    end
 
         response.log_streams.each { |s| log_streams << s.log_stream_name }
-        if log_streams.size == @max_log_streams_per_group
-          @log_streams_next_token = response.next_token
-        end
+        # @log_streams_next_token should become nil unless next_token
+        @log_streams_next_token = response.next_token
       rescue StandardError => boom
         prefix_message = if log_stream_name_prefix.empty?
                            ''


### PR DESCRIPTION
Ingest does not stop if (streams > max_log_streams_per_group) and (streams % max_log_streams_per_group != 0).

When a source log group has 8 streams and max_log_streams_per_group = 7,
the second iteration repeats and the state file is not saved.



