### PR TITLE
ThrottlingException handling enhansement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,6 @@ Metrics/ClassLength:
 Metrics/PerceivedComplexity:
   Max: 14
 Metrics/BlockLength:
-  Max: 40
+  Enabled: false
 Style/DateTime:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ Or install it yourself as:
   state_file_name /mnt/nfs/cloudwatch.state
   interval 60
   max_log_streams_per_group 50
-  error_interval 5          # Time to wait between error conditions before retry
-  limit_events 10000        # Number of events to fetch in any given iteration
-  event_start_time 0        # Do not fetch events before this time (UNIX epoch, miliseconds)
-  oldest_logs_first false   # When true fetch the oldest logs first
-  drop_blank_events true    # Fluentd may throw an exception if a blank event is emitted
-  telemetry false           # Produce statsd telemetry
-  statsd_endpoint localhost # Endpoint to which telemetry should be sent
+  error_interval 5            # Time to wait between error conditions before retry
+  get_log_events_interval 0.0 # Time to pause between get_log_events to reduce throttle error 
+  limit_events 10000          # Number of events to fetch in any given iteration
+  event_start_time 0          # Do not fetch events before this time (UNIX epoch, miliseconds)
+  oldest_logs_first false     # When true fetch the oldest logs first
+  drop_blank_events true      # Fluentd may throw an exception if a blank event is emitted
+  telemetry false             # Produce statsd telemetry
+  statsd_endpoint localhost   # Endpoint to which telemetry should be sent
   <parse>
     @type cloudwatch_ingest
     expression /^(?<message>.+)$/

--- a/lib/fluent/plugin/cloudwatch/ingest/version.rb
+++ b/lib/fluent/plugin/cloudwatch/ingest/version.rb
@@ -2,7 +2,7 @@ module Fluent
   module Plugin
     module Cloudwatch
       module Ingest
-        VERSION = '1.6.0'.freeze
+        VERSION = '1.7.0.rc1'.freeze
       end
     end
   end

--- a/lib/fluent/plugin/cloudwatch/ingest/version.rb
+++ b/lib/fluent/plugin/cloudwatch/ingest/version.rb
@@ -2,7 +2,7 @@ module Fluent
   module Plugin
     module Cloudwatch
       module Ingest
-        VERSION = '1.7.0.rc1'.freeze
+        VERSION = '1.7.0.rc2'.freeze
       end
     end
   end

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -34,7 +34,7 @@ module Fluent::Plugin
     config_param :interval, :time, default: 60
     desc 'Time to pause between error conditions'
     config_param :error_interval, :time, default: 5
-    config_param :api_interval, :time
+    config_param :api_interval, :time, default: nil
     desc 'Tag to apply to record'
     config_param :tag, :string, default: 'cloudwatch'
     desc 'Enable AWS SDK logging'

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -230,9 +230,8 @@ module Fluent::Plugin
                    end
 
         response.log_streams.each { |s| log_streams << s.log_stream_name }
-        if log_streams.size == @max_log_streams_per_group
-          @log_streams_next_token = response.next_token
-        end
+        # @log_streams_next_token should become nil unless next_token
+        @log_streams_next_token = response.next_token
       rescue StandardError => boom
         prefix_message = if log_stream_name_prefix.empty?
                            ''

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -35,6 +35,8 @@ module Fluent::Plugin
     desc 'Time to pause between error conditions'
     config_param :error_interval, :time, default: 5
     config_param :api_interval, :time
+    desc 'Time to pause between get_log_events to reduce throttle error'
+    config_param :get_log_events_interval, :float, default: 0.0
     desc 'Tag to apply to record'
     config_param :tag, :string, default: 'cloudwatch'
     desc 'Enable AWS SDK logging'
@@ -256,16 +258,48 @@ module Fluent::Plugin
 
     def process_stream(group, stream, next_token, start_time, state)
       event_count = 0
+      has_stream_timestamp = true if state.store[group][stream]['timestamp']
 
       metric(:increment, 'api.calls.getlogevents.attempted')
-      response = @aws.get_log_events(
-        log_group_name: group,
-        log_stream_name: stream,
-        next_token: next_token,
-        limit: @limit_events,
-        start_time: start_time,
-        start_from_head: @oldest_logs_first
-      )
+      begin
+        param_next_token = next_token
+        param_start_time = start_time
+        retried = false
+
+        begin
+          log.info({'log_group_name': group, 'log_stream_name': stream, 'next_token': param_next_token,
+                    'limit': @limit_events, 'start_time': param_start_time, 'start_from_head': @oldest_logs_first})
+          sleep @get_log_events_interval
+          response = @aws.get_log_events(
+              log_group_name: group,
+              log_stream_name: stream,
+              next_token: param_next_token,
+              limit: @limit_events,
+              start_time: param_start_time,
+              start_from_head: @oldest_logs_first
+          )
+        rescue Aws::CloudWatchLogs::Errors::InvalidParameterException
+          raise if retried
+
+          metric(:increment, 'api.calls.getlogevents.invalid_token')
+          log.error(
+              'cloudwatch token is expired or broken. '\
+                    'trying with timestamp.'
+          )
+          param_next_token = nil
+          param_start_time = state.store[group][stream]['timestamp']
+          param_start_time ||= @event_start_time
+          retried = true
+          retry
+        end
+      rescue Aws::CloudWatchLogs::Errors::ThrottlingException,
+          Aws::CloudWatchLogs::Errors::ServiceUnavailableException
+        # on temporary error, save the current state to retry next time
+        if has_stream_timestamp
+          state.new_store[group][stream] = state.store[group][stream]
+        end
+        raise  # handle as error in run method
+      end
 
       response.events.each do |e|
         begin
@@ -277,8 +311,6 @@ module Fluent::Plugin
       end
 
       log.info("#{event_count} events processed for stream #{stream}")
-
-      has_stream_timestamp = true if state.store[group][stream]['timestamp']
 
       if !has_stream_timestamp && response.events.count.zero?
         # This stream has returned no data ever.
@@ -335,33 +367,6 @@ module Fluent::Plugin
                     @event_start_time,
                     state
                   )
-                rescue Aws::CloudWatchLogs::Errors::InvalidParameterException
-                  metric(:increment, 'api.calls.getlogevents.invalid_token')
-                  log.error(
-                    'cloudwatch token is expired or broken. '\
-                    'trying with timestamp.'
-                  )
-
-                  # try again with timestamp instead of forward token
-                  begin
-                    timestamp = state.store[group][stream]['timestamp']
-                    timestamp ||= @event_start_time
-
-                    event_count += process_stream(group,
-                                                  stream,
-                                                  nil,
-                                                  timestamp,
-                                                  state)
-                  rescue StandardError => boom
-                    log.error(
-                      'Unable to retrieve events for stream '\
-                      "#{stream} in group #{group}: "\
-                      "#{boom.inspect}"\
-                    )
-                    metric(:increment, 'api.calls.getlogevents.failed')
-                    sleep @error_interval
-                    next
-                  end
                 rescue StandardError => boom
                   log.error("Unable to retrieve events for stream #{stream} "\
                             "in group #{group}: #{boom.inspect}")

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 require 'aws-sdk'
 require 'fluent/config/error'
 require 'fluent/plugin/input'

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -291,7 +291,8 @@ module Fluent::Plugin
           retry
         end
       rescue Aws::CloudWatchLogs::Errors::ThrottlingException,
-          Aws::CloudWatchLogs::Errors::ServiceUnavailableException
+          Aws::CloudWatchLogs::Errors::ServiceUnavailableException,
+          Seahorse::Client::NetworkingError
         # on temporary error, save the current state to retry next time
         if has_stream_timestamp
           state.new_store[group][stream] = state.store[group][stream]

--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -34,6 +34,8 @@ module Fluent::Plugin
     desc 'Time to pause between error conditions'
     config_param :error_interval, :time, default: 5
     config_param :api_interval, :time, default: nil
+    desc 'Time to pause between get_log_events to reduce throttle error'
+    config_param :get_log_events_interval, :float, default: 0.0
     desc 'Tag to apply to record'
     config_param :tag, :string, default: 'cloudwatch'
     desc 'Enable AWS SDK logging'
@@ -254,16 +256,48 @@ module Fluent::Plugin
 
     def process_stream(group, stream, next_token, start_time, state)
       event_count = 0
+      has_stream_timestamp = true if state.store[group][stream]['timestamp']
 
       metric(:increment, 'api.calls.getlogevents.attempted')
-      response = @aws.get_log_events(
-        log_group_name: group,
-        log_stream_name: stream,
-        next_token: next_token,
-        limit: @limit_events,
-        start_time: start_time,
-        start_from_head: @oldest_logs_first
-      )
+      begin
+        param_next_token = next_token
+        param_start_time = start_time
+        retried = false
+
+        begin
+          log.info({'log_group_name': group, 'log_stream_name': stream, 'next_token': param_next_token,
+                    'limit': @limit_events, 'start_time': param_start_time, 'start_from_head': @oldest_logs_first})
+          sleep @get_log_events_interval
+          response = @aws.get_log_events(
+              log_group_name: group,
+              log_stream_name: stream,
+              next_token: param_next_token,
+              limit: @limit_events,
+              start_time: param_start_time,
+              start_from_head: @oldest_logs_first
+          )
+        rescue Aws::CloudWatchLogs::Errors::InvalidParameterException
+          raise if retried
+
+          metric(:increment, 'api.calls.getlogevents.invalid_token')
+          log.error(
+              'cloudwatch token is expired or broken. '\
+                    'trying with timestamp.'
+          )
+          param_next_token = nil
+          param_start_time = state.store[group][stream]['timestamp']
+          param_start_time ||= @event_start_time
+          retried = true
+          retry
+        end
+      rescue Aws::CloudWatchLogs::Errors::ThrottlingException,
+          Aws::CloudWatchLogs::Errors::ServiceUnavailableException
+        # on temporary error, save the current state to retry next time
+        if has_stream_timestamp
+          state.new_store[group][stream] = state.store[group][stream]
+        end
+        raise  # handle as error in run method
+      end
 
       response.events.each do |e|
         begin
@@ -275,8 +309,6 @@ module Fluent::Plugin
       end
 
       log.info("#{event_count} events processed for stream #{stream}")
-
-      has_stream_timestamp = true if state.store[group][stream]['timestamp']
 
       if !has_stream_timestamp && response.events.count.zero?
         # This stream has returned no data ever.
@@ -333,33 +365,6 @@ module Fluent::Plugin
                     @event_start_time,
                     state
                   )
-                rescue Aws::CloudWatchLogs::Errors::InvalidParameterException
-                  metric(:increment, 'api.calls.getlogevents.invalid_token')
-                  log.error(
-                    'cloudwatch token is expired or broken. '\
-                    'trying with timestamp.'
-                  )
-
-                  # try again with timestamp instead of forward token
-                  begin
-                    timestamp = state.store[group][stream]['timestamp']
-                    timestamp ||= @event_start_time
-
-                    event_count += process_stream(group,
-                                                  stream,
-                                                  nil,
-                                                  timestamp,
-                                                  state)
-                  rescue StandardError => boom
-                    log.error(
-                      'Unable to retrieve events for stream '\
-                      "#{stream} in group #{group}: "\
-                      "#{boom.inspect}"\
-                    )
-                    metric(:increment, 'api.calls.getlogevents.failed')
-                    sleep @error_interval
-                    next
-                  end
                 rescue StandardError => boom
                   log.error("Unable to retrieve events for stream #{stream} "\
                             "in group #{group}: #{boom.inspect}")


### PR DESCRIPTION
We cannot completely avoid ThrottlingException because it is mostly matter of concurrency.
So I suggest: 

- save current state on ThrottlingException and other temporary errors not to reset the state.
- new configuration for sleep to reduce ThrottlingException.
- refactor exiting exception handling.

## log sample

### ThrottlingException 

state is saved before/after the exception
```
2017-12-14 11:56:31 +0900 [info]: #0 [test1] processing stream: test-stream
2017-12-14 11:56:31 +0900 [info]: #0 [test1]  log_group_name="test-group" log_stream_name="test-stream" next_token="f/33743856321123405891826378568446772091912687289125109763" limit=10000 start_time=0 start_from_head=true
2017-12-14 11:56:34 +0900 [error]: #0 [test1] Unable to retrieve events for stream test-stream in group test-group: #<Aws::CloudWatchLogs::Errors::ThrottlingException: Rate exceeded>

2017-12-14 11:58:38 +0900 [info]: #0 [test1] processing stream: test-stream
2017-12-14 11:58:38 +0900 [info]: #0 [test1]  log_group_name="test-group" log_stream_name="test-stream" next_token="f/33743856321123405891826378568446772091912687289125109763" limit=10000 start_time=0 start_from_head=true
```

### InvalidParameterException

next_token and start_time parameter changes after the exception, as it was.
```
2017-12-14 12:13:24 +0900 [info]: #0 [test1] processing stream: test-stream
2017-12-14 12:13:24 +0900 [info]: #0 [test1]  log_group_name="test-group" log_stream_name="test-stream" next_token="f/INVALIDTOKEN" limit=10000 start_time=0 start_from_head=true
2017-12-14 12:13:24 +0900 [error]: #0 [test1] cloudwatch token is expired or broken. trying with timestamp.
2017-12-14 12:13:24 +0900 [info]: #0 [test1]  log_group_name="test-group" log_stream_name="test-stream" next_token=nil limit=10000 start_time=1513126849382 start_from_head=true
2017-12-14 12:13:24 +0900 [info]: #0 [test1] 1 events processed for stream test-stream

2017-12-14 12:21:44 +0900 [info]: #0 [test1] processing stream: test-stream
2017-12-14 12:21:44 +0900 [info]: #0 [test1]  log_group_name="test-group" log_stream_name="test-stream" next_token="f/33743856321123405891826378568446772091912687289125109763" limit=10000 start_time=0 start_from_head=true
2017-12-14 12:21:44 +0900 [info]: #0 [test1] 0 events processed for stream test-stream
```

