### PR TITLE
Prevent looping end of event stream

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/in_cloudwatch_ingest.rb
@@ -302,12 +302,14 @@ module Fluent::Plugin
         raise # handle as error in run method
       end
 
-      response.events.each do |e|
-        begin
-          emit(e, group, stream)
-          event_count += 1
-        rescue StandardError => boom
-          log.error("Failed to emit event #{e}: #{boom.inspect}")
+      if response.next_forward_token != param_next_token
+        response.events.each do |e|
+          begin
+            emit(e, group, stream)
+            event_count += 1
+          rescue StandardError => boom
+            log.error("Failed to emit event #{e}: #{boom.inspect}")
+          end
         end
       end
 


### PR DESCRIPTION
When retrieving log events from AWS CloudWatch, when you reach the end of the log stream the next token will loop to the same location. This is used to detect when the end of the stream has been reached.

I was wondering why this plugin would re-emit events or why it would loop so I manually ran some AWS CLI commands and followed the logic implemented in the plugin. I found out it wouldn't check to see if it reached the end of the log events for the stream by comparing tokens.

This has been working perfectly so far and I haven't seen any duplicated events.