### PR TITLE
Change type from string to regexp in CloudWatchIngestParser

### DIFF
--- a/lib/fluent/plugin/parser_cloudwatch_ingest.rb
+++ b/lib/fluent/plugin/parser_cloudwatch_ingest.rb
@@ -9,7 +9,7 @@ module Fluent
     class CloudwatchIngestParser < RegexpParser
       Plugin.register_parser('cloudwatch_ingest', self)
 
-      config_param :expression, :string, default: '^(?<message>.+)$'
+      config_param :expression, :regexp, default: '^(?<message>.+)$'
       config_param :time_format, :string, default: '%Y-%m-%d %H:%M:%S.%L'
       config_param :event_time, :bool, default: true
       config_param :inject_group_name, :bool, default: true


### PR DESCRIPTION
This fixes #28 which blows up the line I changed because string does not understand named captures.  Changing the type to rexegp fixes this.  I have this running and correctly ingesting logs on fluend 1.7!